### PR TITLE
Fix ModelPicker accuracy computation

### DIFF
--- a/coda/baselines/uncertainty.py
+++ b/coda/baselines/uncertainty.py
@@ -20,4 +20,4 @@ class Uncertainty(IID):
             idxs = torch.nonzero(ties, as_tuple=True)[0]
             chosen_idx_local = idxs[torch.randperm(len(idxs))[0]]
         chosen_idx_global = self.d_u_idxs[chosen_idx_local]
-        return chosen_idx_global, chosen_q
+        return chosen_idx_global, chosen_q.item()


### PR DESCRIPTION
## Summary
- keep per-model correct counts when labels arrive
- choose best model using accuracy across labeled data
- correct ActiveTesting label acquisition
- return numeric probability in Uncertainty baseline

## Testing
- `python -m py_compile coda/baselines/modelpicker.py coda/baselines/vma.py coda/baselines/activetesting.py coda/baselines/iid.py coda/baselines/uncertainty.py coda/coda.py datasets.py metrics.py oracle.py surrogates.py options.py main.py aggregate_results.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5f2316f4832d9a0bd8f52213c8cb