### PR TITLE
Add task argument and launcher script

### DIFF
--- a/launch_missing_tasks.py
+++ b/launch_missing_tasks.py
@@ -1,0 +1,33 @@
+import argparse
+import json
+import os
+import subprocess
+
+
+def main():
+    p = argparse.ArgumentParser(description="Launch epsilon grid search for missing tasks")
+    p.add_argument("--pred-dir", default="data", help="Directory containing prediction tensors")
+    p.add_argument("--results", default="best_epsilons.json", help="Path to best epsilon results json")
+    args = p.parse_args()
+
+    existing = set()
+    if os.path.exists(args.results):
+        with open(args.results) as f:
+            data = json.load(f)
+        for k in data.keys():
+            base = k[:-3] if k.endswith(".pt") else k
+            existing.add(base)
+
+    pt_files = [f for f in os.listdir(args.pred_dir) if f.endswith(".pt") and not f.endswith("_labels.pt")]
+    pt_files.sort()
+    for fname in pt_files:
+        task = fname[:-3]
+        if task in existing:
+            continue
+        cmd = ["rungpu", "python", "modelselector_eps_gridsearch_v2.py", "--task", task, "--pred-dir", args.pred_dir]
+        print("Launching:", " ".join(cmd))
+        subprocess.run(cmd)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow specifying a task when running `modelselector_eps_gridsearch_v2.py`
- add a helper script `launch_missing_tasks.py` to run grid search on tasks missing from `best_epsilons.json`

## Testing
- `python -m py_compile modelselector_eps_gridsearch_v2.py launch_missing_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5dfd561c832d812118571e08d5df