### PR TITLE
Remove Dirichlet approximations

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,6 @@ def parse_args():
     parser.add_argument("--alpha", default=0.9, type=float)
     parser.add_argument("--learning-rate-ratio", default=0.01, type=float)
     parser.add_argument("--update-rule", default="hard", help="Hard or soft dirichlet confusion matrix updates")
-    parser.add_argument("--beta-approx", default=None, help="{None, counts, mom, inflated}")
 
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- remove beta approximation code and unused parameter
- always compute P(best) using row mixture
- simplify eig calculation and CODA class initialization
- drop `--beta-approx` CLI option
- delete unused `compute_p_best_dirichlet`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ca900ea38832db7ff6396f6cc2c29