### PR TITLE
Remove update_rule option from CODA

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,6 @@ def parse_args():
     parser.add_argument("--temperature", default=1.0, type=float)
     parser.add_argument("--alpha", default=0.9, type=float)
     parser.add_argument("--learning-rate-ratio", default=0.01, type=float)
-    parser.add_argument("--update-rule", default="hard", help="Hard or soft dirichlet confusion matrix updates")
 
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- assume hard confusion matrix updates and drop `update_rule` parameter
- remove CLI option for `update-rule`

## Testing
- `python -m py_compile coda/coda.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684d9376680c832d9911ba2229f31663