### PR TITLE
Remove unused accuracy and torchmetrics

### DIFF
--- a/coda/oracle.py
+++ b/coda/oracle.py
@@ -2,10 +2,9 @@ import torch
 
 
 class Oracle:
-    def __init__(self, dataset, loss_fn=None, accuracy_fn=None):
+    def __init__(self, dataset, loss_fn=None):
         self.dataset = dataset
         self.loss_fn = loss_fn
-        self.accuracy_fn = accuracy_fn
         self.device = dataset.device
         self.labels = dataset.labels
         assert self.labels is not None, "Oracle needs labels!"
@@ -24,21 +23,6 @@ class Oracle:
         return self.loss_fn(preds.view(-1, C), self.labels.repeat(H), 
                             reduction='none').view(H, N).mean(dim=1)
 
-    def true_accuracies(self, preds):
-        H, N, C = preds.shape
-        accuracies = []
-        batch_size = 100  # Adjust this value based on your GPU memory
-        for i in range(0, H, batch_size):
-            batch_end = min(i + batch_size, H)
-            batch_preds = preds[i:batch_end]
-            batch_labels = self.labels
-            batch_acc = []
-            for j in range(batch_end - i):
-                acc = self.accuracy_fn(batch_preds[j], batch_labels)
-                batch_acc.append(acc)
-            accuracies.extend([acc.item() for acc in batch_acc])
-            torch.cuda.empty_cache()
-        return accuracies
 
     def __call__(self, idx):
         return self.labels[idx].item()

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import numpy as np
 import torch
 from tqdm import tqdm
 import os
-from torchmetrics import Accuracy
 
 from coda import CODA
 from coda.baselines import IID, ActiveTesting, VMA, ModelPicker, Uncertainty
@@ -34,7 +33,6 @@ def parse_args():
     parser.add_argument("--data-dir", default='data')
 
     # benchmarking settings
-    parser.add_argument("--acc", help="Accuracy fn. Options specific to dataset, see main.py.", default="acc")
     parser.add_argument("--iters", type=int, default=100)
     parser.add_argument("--seeds", type=int, default=5) # how many seeds to use - one experiment per seed
     parser.add_argument("--force-rerun", action="store_true", help="Overwrite existing runs.")
@@ -120,9 +118,8 @@ def main():
     dataset = Dataset(os.path.join(args.data_dir, args.task + ".pt"), device=device)
 
     # Create oracle
-    accuracy_fn = Accuracy(task="multiclass", num_classes=126, average="micro") # TODO
     loss_fn = LOSS_FNS[args.loss]
-    oracle = Oracle(dataset, loss_fn=loss_fn, accuracy_fn=accuracy_fn)
+    oracle = Oracle(dataset, loss_fn=loss_fn)
     
     ## Model selection loop
     # create mlflow 'experiment' (= dataset/task)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "torch",
     "tqdm",
     "numpy",
-    "torchmetrics"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- drop torchmetrics dependency
- eliminate `accuracy_fn` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'mlflow')*

------
https://chatgpt.com/codex/tasks/task_e_684e0861e928832d9d73ff46b25e7bff